### PR TITLE
anacron and disable root emails

### DIFF
--- a/containers/web/Dockerfile
+++ b/containers/web/Dockerfile
@@ -32,6 +32,8 @@ RUN sed -i "s/error_reporting = .*$/error_reporting = E_ERROR | E_WARNING | E_PA
 RUN sed -i "s/post_max_size = .*$/post_max_size = 810M/" /etc/php5/apache2/php.ini
 RUN sed -i "s/upload_max_filesize = .*$/upload_max_filesize = 800M/" /etc/php5/apache2/php.ini
 RUN sed -i "s/max_execution_time = .*$/max_execution_time = 300/" /etc/php5/apache2/php.ini
+RUN sed -i "s/session.gc_probability = .*$/session.gc_probability = 1/" /etc/php5/apache2/php.ini
+RUN sed -i "s/session.gc_divisor = .*$/session.gc_divisor = 100/" /etc/php5/apache2/php.ini
 
 # Setup persistent environment variables
 ENV XIBO_VERSION=1.8.0-alpha3 XMR_HOST=xibo-cms-xmr

--- a/containers/web/Dockerfile
+++ b/containers/web/Dockerfile
@@ -14,8 +14,6 @@ RUN apt-get update && apt-get install -y \
   mysql-client \
   php5-mysql \
   php5-gd \
-  php-pear \
-  php-apc \
   php5-curl \
   curl \
   php5-mcrypt \
@@ -34,6 +32,10 @@ RUN sed -i "s/upload_max_filesize = .*$/upload_max_filesize = 800M/" /etc/php5/a
 RUN sed -i "s/max_execution_time = .*$/max_execution_time = 300/" /etc/php5/apache2/php.ini
 RUN sed -i "s/session.gc_probability = .*$/session.gc_probability = 1/" /etc/php5/apache2/php.ini
 RUN sed -i "s/session.gc_divisor = .*$/session.gc_divisor = 100/" /etc/php5/apache2/php.ini
+
+# Disable cron sending emails to root
+RUN awk '/PATH=/ { print; print "MAILTO=\"\""; next}1' /etc/crontab > /tmp/crontab && mv /tmp/crontab /etc/crontab
+RUN awk '/LOGNAME=root/ { print; print "MAILTO=\"\""; next}1' /etc/anacrontab > /tmp/anacrontab && mv /tmp/anacrontab /etc/anacrontab
 
 # Setup persistent environment variables
 ENV XIBO_VERSION=1.8.0-alpha3 XMR_HOST=xibo-cms-xmr

--- a/containers/web/Dockerfile
+++ b/containers/web/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update && apt-get install -y \
   php5-mcrypt \
   php5-zmq \
   ssmtp \
-  wget
+  wget \
+  anacron
 
 # Enable apache mods and PHP extensions
 RUN a2enmod php5 && a2enmod rewrite && php5enmod mcrypt

--- a/containers/web/entrypoint.sh
+++ b/containers/web/entrypoint.sh
@@ -125,7 +125,10 @@ then
     
     # Configure MySQL Backup
     echo "Configuring Backups"
-    echo "0 1 * * *     root  /bin/mkdir -p /var/www/backup/db && /usr/bin/mysqldump -u root -p$MYSQL_ENV_MYSQL_ROOT_PASSWORD -h mysql cms | gzip > /var/www/backup/db/latest.sql.gz" > /var/www/backup/cron/sql
+    echo "#!/bin/bash" > /var/www/backup/cron/sql
+    echo "" >> /var/www/backup/cron/sql
+    echo "/bin/mkdir -p /var/www/backup/db" >> /var/www/backup/cron/sql
+    echo "/usr/bin/mysqldump -u root -p$MYSQL_ENV_MYSQL_ROOT_PASSWORD -h mysql cms | gzip > /var/www/backup/db/latest.sql.gz" >> /var/www/backup/cron/sql
     
     # Remove the installer
     echo "Removing the installer"
@@ -142,8 +145,10 @@ then
   cp /var/www/backup/cron/xibo /etc/cron.d/xibo
   
   # Ensure there's a crontab for backups
-  cp /var/www/backup/cron/sql /etc/cron.d/sql
-  /bin/chmod 600 /etc/cron.d/sql
+  # Use anacron for this so we get backups even if
+  # the box isn't on 24/7
+  cp /var/www/backup/cron/sql /etc/cron.daily/sql
+  /bin/chmod 700 /etc/cron.daily/sql
 fi
 
 # Configure SSMTP to send emails if required
@@ -166,6 +171,7 @@ fi
 
 echo "Starting cron"
 /usr/sbin/cron
+/usr/sbin/anacron
 
 echo "Starting webserver"
 /usr/local/bin/httpd-foreground

--- a/containers/web/entrypoint.sh
+++ b/containers/web/entrypoint.sh
@@ -121,14 +121,14 @@ then
     mysql -D cms -u root -p$MYSQL_ENV_MYSQL_ROOT_PASSWORD -h mysql -e "UPDATE \`setting\` SET \`value\`='$MAINTENANCE_KEY' WHERE \`setting\`='MAINTENANCE_KEY' LIMIT 1"
 
     mkdir -p /var/www/backup/cron
-    echo "*/5 * * * *   root  /usr/bin/wget -O /dev/null -o /dev/null http://localhost/maint/?key=$MAINTENANCE_KEY" > /var/www/backup/cron/xibo
+    echo "*/5 * * * *   root  /usr/bin/wget -O /dev/null -o /dev/null http://localhost/maint/?key=$MAINTENANCE_KEY" > /var/www/backup/cron/cms-maintenance
     
     # Configure MySQL Backup
     echo "Configuring Backups"
-    echo "#!/bin/bash" > /var/www/backup/cron/sql
-    echo "" >> /var/www/backup/cron/sql
-    echo "/bin/mkdir -p /var/www/backup/db" >> /var/www/backup/cron/sql
-    echo "/usr/bin/mysqldump -u root -p$MYSQL_ENV_MYSQL_ROOT_PASSWORD -h mysql cms | gzip > /var/www/backup/db/latest.sql.gz" >> /var/www/backup/cron/sql
+    echo "#!/bin/bash" > /var/www/backup/cron/cms-db-backup
+    echo "" >> /var/www/backup/cron/cms-db-backup
+    echo "/bin/mkdir -p /var/www/backup/db" >> /var/www/backup/cron/cms-db-backup
+    echo "/usr/bin/mysqldump -u root -p$MYSQL_ENV_MYSQL_ROOT_PASSWORD -h mysql cms | gzip > /var/www/backup/db/latest.sql.gz" >> /var/www/backup/cron/cms-db-backup
     
     # Remove the installer
     echo "Removing the installer"
@@ -142,13 +142,13 @@ then
   /usr/sbin/groupadd ssmtp
   
   # Ensure there's a crontab for maintenance
-  cp /var/www/backup/cron/xibo /etc/cron.d/xibo
+  cp /var/www/backup/cron/cms-maintenance /etc/cron.d/cms-maintenance
   
   # Ensure there's a crontab for backups
   # Use anacron for this so we get backups even if
   # the box isn't on 24/7
-  cp /var/www/backup/cron/sql /etc/cron.daily/sql
-  /bin/chmod 700 /etc/cron.daily/sql
+  cp /var/www/backup/cron/cms-db-backup /etc/cron.daily/cms-db-backup
+  /bin/chmod 700 /etc/cron.daily/cms-db-backup
 fi
 
 # Configure SSMTP to send emails if required


### PR DESCRIPTION
Move to anacron for database backups (so they get run if the container isn't running during the normal backup window) and also prevent cron from sending emails to root (ie root@gmail.com)