### PR TITLE
SELinux compatibility

### DIFF
--- a/cms_remote-mysql.yml
+++ b/cms_remote-mysql.yml
@@ -1,4 +1,4 @@
-version: "2.1"
+:version: "2.1"
 
 services:
     cms-xmr:
@@ -11,11 +11,11 @@ services:
     cms-web:
         image: xibosignage/xibo-cms:release-2.3.4
         volumes:
-            - "./shared/cms/custom:/var/www/cms/custom"
-            - "./shared/backup:/var/www/backup"
-            - "./shared/cms/web/theme/custom:/var/www/cms/web/theme/custom"
-            - "./shared/cms/library:/var/www/cms/library"
-            - "./shared/cms/web/userscripts:/var/www/cms/web/userscripts"
+            - "./shared/cms/custom:/var/www/cms/custom:Z"
+            - "./shared/backup:/var/www/backup:Z"
+            - "./shared/cms/web/theme/custom:/var/www/cms/web/theme/custom:Z"
+            - "./shared/cms/library:/var/www/cms/library:Z"
+            - "./shared/cms/web/userscripts:/var/www/cms/web/userscripts:Z"
         restart: always
         links:
             - cms-xmr:50001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     cms-db:
         image: mysql:5.6
         volumes:
-            - "./shared/db:/var/lib/mysql:z"
+            - "./shared/db:/var/lib/mysql:Z"
         environment:
             - MYSQL_DATABASE=cms
             - MYSQL_USER=cms
@@ -22,11 +22,11 @@ services:
     cms-web:
         image: xibosignage/xibo-cms:release-2.3.4
         volumes:
-            - "./shared/cms/custom:/var/www/cms/custom:z"
-            - "./shared/backup:/var/www/backup:z"
-            - "./shared/cms/web/theme/custom:/var/www/cms/web/theme/custom:z"
-            - "./shared/cms/library:/var/www/cms/library:z"
-            - "./shared/cms/web/userscripts:/var/www/cms/web/userscripts:z"
+            - "./shared/cms/custom:/var/www/cms/custom:Z"
+            - "./shared/backup:/var/www/backup:Z"
+            - "./shared/cms/web/theme/custom:/var/www/cms/web/theme/custom:Z"
+            - "./shared/cms/library:/var/www/cms/library:Z"
+            - "./shared/cms/web/userscripts:/var/www/cms/web/userscripts:Z"
         restart: always
         links:
             - cms-db:mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     cms-db:
         image: mysql:5.6
         volumes:
-            - "./shared/db:/var/lib/mysql"
+            - "./shared/db:/var/lib/mysql:z"
         environment:
             - MYSQL_DATABASE=cms
             - MYSQL_USER=cms
@@ -22,11 +22,11 @@ services:
     cms-web:
         image: xibosignage/xibo-cms:release-2.3.4
         volumes:
-            - "./shared/cms/custom:/var/www/cms/custom"
-            - "./shared/backup:/var/www/backup"
-            - "./shared/cms/web/theme/custom:/var/www/cms/web/theme/custom"
-            - "./shared/cms/library:/var/www/cms/library"
-            - "./shared/cms/web/userscripts:/var/www/cms/web/userscripts"
+            - "./shared/cms/custom:/var/www/cms/custom:z"
+            - "./shared/backup:/var/www/backup:z"
+            - "./shared/cms/web/theme/custom:/var/www/cms/web/theme/custom:z"
+            - "./shared/cms/library:/var/www/cms/library:z"
+            - "./shared/cms/web/userscripts:/var/www/cms/web/userscripts:z"
         restart: always
         links:
             - cms-db:mysql


### PR DESCRIPTION
Enabling read and write to volumes on SELinux enabled systems so that it installs properly without disabling SELinux. This could be added as a note as well. Tested on fedora server 32.