### PR TITLE
Update MySQL from 5.6 to 5.7

### DIFF
--- a/cms_custom-ports.yml.template
+++ b/cms_custom-ports.yml.template
@@ -2,7 +2,7 @@ version: "2.1"
 
 services:
     cms-db:
-        image: mysql:5.6
+        image: mysql:5.7
         volumes:
             - "./shared/db:/var/lib/mysql:Z"
         restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.1"
 
 services:
     cms-db:
-        image: mysql:5.6
+        image: mysql:5.7
         volumes:
             - "./shared/db:/var/lib/mysql:Z"
         environment:


### PR DESCRIPTION
Updates MySQL from **5.6** to **5.7**, as support for **5.6** ended on Feb 2021, see [here](https://en.wikipedia.org/wiki/MySQL#Release_history).

Relates https://github.com/xibosignage/xibo/issues/2469, https://github.com/xibosignage/xibo-cms/pull/1096.