### PR TITLE
Allow use of internal CA signed certificates

### DIFF
--- a/config.env.template
+++ b/config.env.template
@@ -39,6 +39,8 @@ CMS_SMTP_USERNAME=youraccount@gmail.com
 CMS_SMTP_PASSWORD=yourpassword
 ## Use a TLS Connection YES/NO
 CMS_SMTP_USE_TLS=YES
+## SMTP Check TLS Certificate YES/NO
+CMS_SMTP_CHECK_TLS_CERTIFICATE=YES
 ## Use a STARTTLS Connection YES/NO
 CMS_SMTP_USE_STARTTLS=YES
 ## Rewrite domain (the domain your email will appear to come from)


### PR DESCRIPTION
By default, msmtp checks the validity of the certificate chain of the mail server. The new option "CMS_SMTP_CHECK_TLS_CERTIFICATE" allows use of TLS certificates signed by internal Certificate Authority that do not pass the default check. If the user sets "CMS_SMTP_CHECK_TLS_CERTIFICATE" to "NO" then the line "tls_nocertcheck" will be added to /etc/msmtprc (see  dagonix/xibo-cms/docker/entrypoint.sh commit).