### PR TITLE
fix: remove version attribute in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2.1"
-
 services:
     cms-db:
         image: mysql:8.4


### PR DESCRIPTION
version attribute is obsolete since docker compose v2

Everytime we execute docker compose commands, this message is printed and this is really annoying:
```
time="..." level=warning msg=".../docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
```

Thanks